### PR TITLE
Refactor code to be more idiomatic and consume less momery

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -44,26 +44,25 @@ fn unpack_zstd(path: &Path, dest: &Path) {
 pub fn unpack(source: &String, dest: &String) -> Result<(), ()> {
     let source_path = Path::new(source);
     let dest_path = Path::new(dest);
-    if source_path.exists() && source_path.is_file() {
-        if source.ends_with(".gz") {
-            unpack_gz(source_path, dest_path);
-        } else if source.ends_with(".xz") {
-            unpack_xz(source_path, dest_path);
-        } else if source.ends_with(".bz2") {
-            unpack_bz2(source_path, dest_path);
-        } else if source.ends_with(".zstd") {
-            unpack_zstd(source_path, dest_path);
-        } else if source.ends_with("zip") {
-            unpack_zip(source_path, dest_path);
-        } else {
-            panic!("compression not implemented yet")
-        }
-        return Ok(());
-    } else {
+    if !source_path.exists() || !source_path.is_file() {
         panic!("Path is not valid")
     }
+    if source.ends_with(".gz") {
+        unpack_gz(source_path, dest_path);
+    } else if source.ends_with(".xz") {
+        unpack_xz(source_path, dest_path);
+    } else if source.ends_with(".bz2") {
+        unpack_bz2(source_path, dest_path);
+    } else if source.ends_with(".zstd") {
+        unpack_zstd(source_path, dest_path);
+    } else if source.ends_with("zip") {
+        unpack_zip(source_path, dest_path);
+    } else {
+        panic!("compression not implemented yet")
+    }
+    Ok(())
 }
 
-pub fn cleanup(path: &String) {
+pub fn cleanup(path: &str) {
     remove_dir_all(path).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,13 @@ mod spec_builder;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn name_from_file(filename: &String) -> String {
-    return filename
+fn name_from_file(filename: &str) -> String {
+    filename
         .replace(".zip", "")
         .replace(".tar", "")
         .replace(".xz", "")
         .replace(".bz2", "")
-        .replace(".gz", "");
+        .replace(".gz", "")
 }
 
 #[tokio::main(flavor = "multi_thread")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ async fn main() {
         )
         .arg(Arg::new("dest").help("directory to unpack too").index(2))
         .get_matches();
-    let url = matches.get_one::<String>("url").map(|s| s.into());
+    let url = matches.get_one::<String>("url").map(|s| s.as_ref());
     let source = matches
         .get_one::<String>("source")
         .unwrap()
@@ -84,15 +84,8 @@ async fn main() {
     if archive::unpack(&source, &dest) == Ok(()) {
         let name = name_from_file(&source);
         if matches.get_flag("output-spec") {
-            let spec = spec_builder::gen_spec(
-                &source,
-                dest.clone(),
-                &name,
-                version.clone(),
-                license.clone(),
-                url,
-            )
-            .unwrap();
+            let spec =
+                spec_builder::gen_spec(&source, &dest, &name, &version, &license, url).unwrap();
             let spec_file_name = format!("{}.spec", name);
             let spec_path = Path::new(&spec_file_name);
             write(spec_path, spec).expect("unable to write spec");

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ async fn main() {
             write(spec_path, spec).expect("unable to write spec");
             println!("Please update the spec file with release number and change log.")
         }
-        rpm_build::buildrpm(&dest, name, version, license).await;
+        rpm_build::buildrpm(&dest, &name, &version, &license).await;
     }
     archive::cleanup(&dest);
 }

--- a/src/rpm_build.rs
+++ b/src/rpm_build.rs
@@ -34,12 +34,12 @@ async fn buildpkg(name: &str, version: &str, license: &str) -> RPMBuilder {
     }
 }
 
-pub async fn buildrpm(source: &String, name: &str, version: &str, license: &str) {
+pub async fn buildrpm(source: &str, name: &str, version: &str, license: &str) {
     let current_dir = env::current_dir().unwrap();
 
     let wd = Path::new(source);
     assert!(env::set_current_dir(wd).is_ok());
-    let mut pkg = buildpkg(&name, &version, &license).await;
+    let mut pkg = buildpkg(name, version, license).await;
     for entry in walkdir::WalkDir::new(".")
         .into_iter()
         .filter_map(|e| e.ok())

--- a/src/rpm_build.rs
+++ b/src/rpm_build.rs
@@ -34,7 +34,7 @@ async fn buildpkg(name: &str, version: &str, license: &str) -> RPMBuilder {
     }
 }
 
-pub async fn buildrpm(source: &String, name: String, version: String, license: String) {
+pub async fn buildrpm(source: &String, name: &str, version: &str, license: &str) {
     let current_dir = env::current_dir().unwrap();
 
     let wd = Path::new(source);

--- a/src/rpm_build.rs
+++ b/src/rpm_build.rs
@@ -3,22 +3,16 @@ use std::env;
 use std::path::Path;
 use std::process::exit;
 use std::str::FromStr;
-use sys_info;
-use walkdir;
 
-async fn buildpkg(name: String, version: String, license: String) -> RPMBuilder {
-    let os_release = match sys_info::linux_os_release() {
-        Err(e) => {
-            eprintln!("{}", e);
-            None
-        }
-        Ok(info) => Some(info),
-    };
+async fn buildpkg(name: &str, version: &str, license: &str) -> RPMBuilder {
+    let os_release = sys_info::linux_os_release().map_err(|e| {
+        eprintln!("{}", e);
+    });
     // rpm-rs handles setting up the compressor lets use it
     let pkg = rpm::RPMBuilder::new(
-        name.as_str(),
-        version.as_str(),
-        license.as_str(),
+        name,
+        version,
+        license,
         "noarch",
         "autogenrated sddm theme rpm",
     )
@@ -45,18 +39,16 @@ pub async fn buildrpm(source: &String, name: String, version: String, license: S
 
     let wd = Path::new(source);
     assert!(env::set_current_dir(wd).is_ok());
-    let mut pkg = buildpkg(name.clone(), version, license).await;
+    let mut pkg = buildpkg(&name, &version, &license).await;
     for entry in walkdir::WalkDir::new(".")
         .into_iter()
         .filter_map(|e| e.ok())
     {
         let file = entry.path();
         if Path::new(&file.as_os_str()).is_file() {
-            let dest = format!(
-                "{}",
-                file.to_string_lossy()
-                    .replace("./", "/usr/share/sddm/themes/")
-            );
+            let dest = file
+                .to_string_lossy()
+                .replace("./", "/usr/share/sddm/themes/");
             let options = rpm::RPMFileOptions::new(dest);
             pkg = pkg.with_file_async(file, options).await.expect("Error");
         }

--- a/src/spec_builder.rs
+++ b/src/spec_builder.rs
@@ -5,53 +5,53 @@ use std::path::Path;
 
 const DEFAULT_SPEC_TEMPLATE: &str = include_str!("../templates/spec.hbs");
 #[derive(Serialize)]
-pub struct SpecParams {
+pub struct SpecParams<'a> {
     // Name of the RPM
-    pub name: String,
+    pub name: &'a str,
     // Description of the RPM
-    pub summary: String,
+    pub summary: &'a str,
     // version of package
-    pub version: String,
+    pub version: &'a str,
     // License of the *binary* contents of the RPM
-    pub license: String,
+    pub license: &'a str,
     // URL to a home page for this package
-    pub url: Option<String>,
+    pub url: Option<&'a str>,
     // commands to build the rpm
-    pub build_commands: String,
+    pub build_commands: &'a str,
     // files in rpm
-    pub files: String,
+    pub files: &'a str,
     // source files
-    pub source: String,
+    pub source: &'a str,
 }
 
 pub fn gen_spec(
     source: &str,
-    unpacked: String,
+    unpacked: &str,
     name: &str,
-    version: String,
-    license: String,
-    url: Option<String>,
+    version: &str,
+    license: &str,
+    url: Option<&str>,
 ) -> Result<String, ()> {
-    let build_commands = gen_build_commands(&unpacked, &name);
+    let build_commands = gen_build_commands(unpacked, name);
     let files = format!("%{{_datadir}}/sddm/themes/{}", name);
     let summary = format!("Auto genrated specfile for {} sddm theme", name);
     let mut handlebars = Handlebars::new();
     let data = SpecParams {
-        name: name.to_string(),
-        summary,
+        name,
+        summary: &summary,
         version,
         license,
         url,
-        build_commands,
-        files,
-        source: source.to_owned(),
+        build_commands: &build_commands,
+        files: &files,
+        source,
     };
     handlebars
-        .register_template_string(&name, DEFAULT_SPEC_TEMPLATE)
+        .register_template_string(name, DEFAULT_SPEC_TEMPLATE)
         .unwrap();
-    return Ok(handlebars
-        .render(&name, &data)
-        .expect("error rendering template"));
+    Ok(handlebars
+        .render(name, &data)
+        .expect("error rendering template"))
 }
 
 fn gen_build_commands(source: &str, name: &str) -> String {

--- a/src/spec_builder.rs
+++ b/src/spec_builder.rs
@@ -25,9 +25,9 @@ pub struct SpecParams {
 }
 
 pub fn gen_spec(
-    source: &String,
+    source: &str,
     unpacked: String,
-    name: String,
+    name: &str,
     version: String,
     license: String,
     url: Option<String>,
@@ -37,24 +37,24 @@ pub fn gen_spec(
     let summary = format!("Auto genrated specfile for {} sddm theme", name);
     let mut handlebars = Handlebars::new();
     let data = SpecParams {
-        name: name.clone(),
-        summary: summary,
-        version: version,
-        license: license,
-        url: url,
-        build_commands: build_commands,
-        files: files,
+        name: name.to_string(),
+        summary,
+        version,
+        license,
+        url,
+        build_commands,
+        files,
         source: source.to_owned(),
     };
     handlebars
-        .register_template_string(&name.as_str(), DEFAULT_SPEC_TEMPLATE)
+        .register_template_string(&name, DEFAULT_SPEC_TEMPLATE)
         .unwrap();
     return Ok(handlebars
-        .render(&name.as_str(), &data)
+        .render(&name, &data)
         .expect("error rendering template"));
 }
 
-fn gen_build_commands(source: &String, name: &String) -> String {
+fn gen_build_commands(source: &str, name: &str) -> String {
     let mut build_commands = String::new();
     let current_dir = env::current_dir().unwrap();
     let wd = Path::new(&source);


### PR DESCRIPTION
### Changes:
- Short circuit conditional statements, keeping the happy path of the code as the main branch.
- Pet peeve: remove unnecessary return statement since Rust is an expressive language.
- Use references for objects wherever possible to prevent unneeded copying. For example: `&str` or `&'a str` is used instead of `String`.
- Use `map` or `map_err` for `Result`s and `Option`s when only one variant needs to be dealt with.
- Move cleanup invocation outside of error checking since it is called unconditionally.